### PR TITLE
add-retry-on-timeout-errors - Add retries to TimeoutErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ It's designed to handle both network errors and service issues, such as rate lim
 -   Exponential backoff for retry delays.
 -   Support for `Retry-After` and `X-RateLimit-Reset` headers.
 -   Customizable retry conditions.
--   Allow to abort wait between retries with fetch signal and AbortController
+-   Automatic retries on timeout errors: it captures errors with name equal to TimeoutError and retries them.
+-   Allow to abort wait between retries with fetch signal and AbortController (with the exception of TimeoutError as explained above)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It's designed to handle both network errors and service issues, such as rate lim
 -   Exponential backoff for retry delays.
 -   Support for `Retry-After` and `X-RateLimit-Reset` headers.
 -   Customizable retry conditions.
--   Automatic retries on timeout errors: it captures errors with name equal to TimeoutError and retries them.
--   Allow to abort wait between retries with fetch signal and AbortController (with the exception of TimeoutError as explained above)
+-   Timeout option for the fetch request.
+-   Allow to abort wait between retries with fetch signal and AbortController.
 
 ## Installation
 

--- a/src/fetch-with-retries.ts
+++ b/src/fetch-with-retries.ts
@@ -178,7 +178,10 @@ function isResponseThatHaveToBeRetried(response: Response): boolean {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isErrorThatHaveToBeRetried(error: any): boolean {
-    return error?.cause?.code && RETRY_ERROR_CODES.includes(error.cause.code);
+    return (
+        (error?.cause?.code && RETRY_ERROR_CODES.includes(error.cause.code)) ||
+        error.name === 'TimeoutError'
+    );
 }
 
 function wait(

--- a/src/fetch-with-retries.ts
+++ b/src/fetch-with-retries.ts
@@ -159,7 +159,7 @@ export async function fetchWithRetries(
             case !signal && !!timeout:
                 return AbortSignal.timeout(timeout);
             case !!signal && !!timeout:
-                // eslint-disable-line @typescript-eslint/no-explicit-any
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 return (AbortSignal as any).any([
                     signal,
                     AbortSignal.timeout(timeout)

--- a/test/fetch-with-retries-real-network.spec.ts
+++ b/test/fetch-with-retries-real-network.spec.ts
@@ -1,0 +1,70 @@
+import { describe, after, test } from 'node:test';
+import { equal, deepStrictEqual } from 'node:assert';
+import { fetchWithRetries } from '../src/index';
+import { createTestServer } from './util/test-server';
+
+describe('fetch-with-retries-real-network', async () => {
+    const server = createTestServer();
+
+    await after(() => {
+        server.close();
+    });
+
+    await test('should return the response if ok', async () => {
+        server.setRequestListener((req, res) => {
+            res.writeHead(200);
+            res.end(JSON.stringify({ message: 'ok' }));
+        });
+
+        let retries = 0;
+
+        const response = await fetchWithRetries('http://localhost:30000', {
+            method: 'GET',
+            retryOptions: {
+                onRetry: () => {
+                    retries++;
+                }
+            }
+        });
+
+        equal(retries, 0, 'retries');
+        equal(response.ok, true);
+        const body = await response.json();
+        deepStrictEqual(body, { message: 'ok' });
+    });
+
+    await test('should throw the error after retrying network errors', async () => {
+        let retries = 0;
+        let attempts = 0;
+        let error: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        server.setRequestListener((req, res) => {
+            setTimeout(() => {
+                res.writeHead(200);
+                res.end(JSON.stringify({ message: 'ok' }));
+            }, 1000);
+        });
+
+        try {
+            await fetchWithRetries('http://localhost:30000', {
+                method: 'GET',
+                retryOptions: {
+                    onRetry: params => {
+                        attempts = params.attempt;
+                        retries++;
+                    },
+                    maxRetries: 1,
+                    initialDelay: 0
+                },
+                signal: AbortSignal.timeout(50)
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        equal(retries, 1, 'retries');
+        equal(attempts, 1, 'attempts');
+        equal(error instanceof Error, true, 'error instance of error');
+        equal(error.name, 'TimeoutError');
+    });
+});

--- a/test/fetch-with-retries-real-network.spec.ts
+++ b/test/fetch-with-retries-real-network.spec.ts
@@ -33,7 +33,35 @@ describe('fetch-with-retries-real-network', async () => {
         deepStrictEqual(body, { message: 'ok' });
     });
 
-    await test('should throw the error after retrying network errors', async () => {
+    await test('should throw error not found after retrying', async () => {
+        let retries = 0;
+        let attempts = 0;
+        let error: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        try {
+            await fetchWithRetries('https://this-url-does-not-exist.com', {
+                method: 'GET',
+                retryOptions: {
+                    onRetry: params => {
+                        attempts = params.attempt;
+                        retries++;
+                    },
+                    maxRetries: 1,
+                    initialDelay: 0
+                }
+            });
+        } catch (e) {
+            error = e;
+        }
+
+        equal(retries, 1, 'retries');
+        equal(attempts, 1, 'attempts');
+        equal(error instanceof Error, true, 'error instance of error');
+        equal(error.message, 'fetch failed');
+        equal(error.cause.code, 'ENOTFOUND');
+    });
+
+    await test('should throw a timeout error after retrying it once', async () => {
         let retries = 0;
         let attempts = 0;
         let error: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/test/fetch-with-retries-real-network.spec.ts
+++ b/test/fetch-with-retries-real-network.spec.ts
@@ -4,10 +4,10 @@ import { fetchWithRetries } from '../src/index';
 import { createTestServer } from './util/test-server';
 
 describe('fetch-with-retries-real-network', async () => {
-    const server = createTestServer();
+    const server = await createTestServer();
 
-    await after(() => {
-        server.close();
+    await after(async () => {
+        await server.close();
     });
 
     await test('should return the response if ok', async () => {

--- a/test/fetch-with-retries.spec.ts
+++ b/test/fetch-with-retries.spec.ts
@@ -250,35 +250,6 @@ describe('fetch-with-retries', async () => {
         equal(nockScope.isDone(), true);
     });
 
-    await test('should return the response if ok after retrying 3 times timeout errors (aborted)', async () => {
-        const nockScope = nock('https://test.com')
-            .get('/test')
-            .times(3)
-            .replyWithError({ name: 'TimeoutError' })
-            .get('/test')
-            .reply(200, { message: 'ok' });
-        let retries = 0;
-        let attempts = 0;
-
-        const response = await fetchWithRetries('https://test.com/test', {
-            method: 'GET',
-            retryOptions: {
-                onRetry: params => {
-                    attempts = params.attempt;
-                    retries++;
-                },
-                initialDelay: 0
-            }
-        });
-
-        equal(retries, 3, 'retries');
-        equal(attempts, 3, 'attempts');
-        equal(response.ok, true);
-        const body = await response.json();
-        deepStrictEqual(body, { message: 'ok' });
-        equal(nockScope.isDone(), true);
-    });
-
     await test('should throw the error without retry if malformed uri', async () => {
         let error: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
         let retries = 0;

--- a/test/fetch-with-retries.spec.ts
+++ b/test/fetch-with-retries.spec.ts
@@ -336,35 +336,6 @@ describe('fetch-with-retries', async () => {
         equal(nockScope.isDone(), true);
     });
 
-    await test('should throw the error after retrying network errors (real one)', async () => {
-        nock.enableNetConnect();
-        let retries = 0;
-        let attempts = 0;
-        let error: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        try {
-            await fetchWithRetries('https://this-url-does-not-exist.com', {
-                method: 'GET',
-                retryOptions: {
-                    onRetry: params => {
-                        attempts = params.attempt;
-                        retries++;
-                    },
-                    maxRetries: 1,
-                    initialDelay: 0
-                }
-            });
-        } catch (e) {
-            error = e;
-        }
-
-        equal(retries, 1, 'retries');
-        equal(attempts, 1, 'attempts');
-        equal(error instanceof Error, true, 'error instance of error');
-        equal(error.message, 'fetch failed');
-        equal(error.cause.code, 'ENOTFOUND');
-    });
-
     await test('should abort while waiting if signal notify an abort', async () => {
         const nockScope = nock('https://test.com')
             .get('/test')

--- a/test/util/test-server.ts
+++ b/test/util/test-server.ts
@@ -18,7 +18,10 @@ export async function createTestServer(port: number = 30000) {
     await once(server, 'listening');
 
     return {
-        close: () => promisify<void>(server.close.bind(server))(),
+        close: () => {
+            server.closeAllConnections();
+            return promisify<void>(server.close.bind(server))();
+        },
         setRequestListener: (newRequestListener: http.RequestListener) => {
             requestListener = newRequestListener;
         }

--- a/test/util/test-server.ts
+++ b/test/util/test-server.ts
@@ -1,0 +1,23 @@
+import * as http from 'http';
+
+/**
+ * Creates a local server. By default it will return a 200 status code with the message 'My first server!'.
+ * @param port The port where the server will listen to. Default is 30000
+ * @returns
+ */
+export function createTestServer(port: number = 30000) {
+    let requestListener: http.RequestListener = (req, res) => {
+        res.writeHead(200);
+        res.end('My first server!');
+    };
+    const server = http.createServer((req, res) => requestListener(req, res));
+
+    server.listen(port, '127.0.0.1');
+
+    return {
+        close: () => server.close(),
+        setRequestListener: (newRequestListener: http.RequestListener) => {
+            requestListener = newRequestListener;
+        }
+    };
+}

--- a/test/util/test-server.ts
+++ b/test/util/test-server.ts
@@ -1,11 +1,13 @@
 import * as http from 'http';
+import { promisify } from 'util';
+import { once } from 'events';
 
 /**
  * Creates a local server. By default it will return a 200 status code with the message 'My first server!'.
  * @param port The port where the server will listen to. Default is 30000
  * @returns
  */
-export function createTestServer(port: number = 30000) {
+export async function createTestServer(port: number = 30000) {
     let requestListener: http.RequestListener = (req, res) => {
         res.writeHead(200);
         res.end('My first server!');
@@ -13,9 +15,10 @@ export function createTestServer(port: number = 30000) {
     const server = http.createServer((req, res) => requestListener(req, res));
 
     server.listen(port, '127.0.0.1');
+    await once(server, 'listening');
 
     return {
-        close: () => server.close(),
+        close: () => promisify<void>(server.close.bind(server))(),
         setRequestListener: (newRequestListener: http.RequestListener) => {
             requestListener = newRequestListener;
         }


### PR DESCRIPTION
Hi @francescorivola, i have added retry on timeout ability.

Please note this solution totally depends on use signal like this:

`signal: AbortSignal.timeout(timeout)`

This way error name should be 'TimeoutError'. 

I took this as reference: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#aborting_a_fetch_operation_with_a_timeout

I am wondering if we should expose a custom timeout property instead and internally make a composition for signals (https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static).

Since this lib is very opinionated maybe we can just assume timeout is used that way. Please, let me know what you think so i can update readme file with the final approach.